### PR TITLE
add: troubleshoot error when .env doesn't exist in root project

### DIFF
--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
+import fs from 'fs'
 
+if (!fs.existsSync('./.env')) {
+  throw new Error(
+    'Missing env!!!\nCopy/rename ".env.example" root directory to ".env"'
+  )
+}
 /**
  * Module dependencies.
  */


### PR DESCRIPTION
provide troubleshoot how to fix if .env doesnt exist rather than throw random error like not setting dialect sql